### PR TITLE
Added Shell Script to Try to Prevent Lock File Error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,15 +15,10 @@ WORKDIR /app
 
 RUN ["dotnet", "restore"]
 
-# Change ownership of created files to main user on host
-# Required to prevent error: 'Project app does not have a lock file'
-RUN chown -R 1000:1000 project.lock.json
-
-# Must mount volumes after changing ownership
 VOLUME nuget:/root/.nuget
 
 EXPOSE 5000
 
-# Specify a url with a wildcard for the host name
-# Note that this argument will be replaced by a manual process
-ENTRYPOINT ["dotnet", "run", "--server.urls=http://*:5000", "--environment=Development"]
+COPY ./dotnet-run.sh /
+RUN chmod +x /dotnet-run.sh
+ENTRYPOINT ["/dotnet-run.sh"]

--- a/dotnet-run.sh
+++ b/dotnet-run.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Set server urls and environment
+dotnet run --server.urls=http://*:5000 --environment=Development
+
+# Change ownership of created files to main user on host
+# Required to prevent error: 'Project app does not have a lock file'
+chown -R 1000:1000 *


### PR DESCRIPTION
Added a shell script to execute chown after dotnet run.

```
# Set server urls and environment
dotnet run --server.urls=http://*:5000 --environment=Development

# Change ownership of created files to main user on host
# Required to prevent error: 'Project app does not have a lock file'
chown -R 1000:1000 *
```

However, mounting a volume that maps to a host folder still generates an error when running the container.

```
docker run -d -p 5000:5000 --name dotnet-aspnet -v $(pwd):/app tonysneed/dotnet-aspnet
```

When including the -v parameter, the following error is generated:
**Project app does not have a lock file.**
